### PR TITLE
Modify the variable REDISSERVICE 

### DIFF
--- a/Setup/wpimgsetup.sh
+++ b/Setup/wpimgsetup.sh
@@ -75,7 +75,7 @@ check_os()
         GROUP='nobody'
         PHPINICONF="${LSWSFD}/lsphp73/etc/php.ini"
         MARIADBCNF='/etc/my.cnf.d/60-server.cnf'
-        REDISSERVICE='/lib/systemd/system/redis.service'
+        REDISSERVICE='/lib/systemd/system/redis-server.service'
         REDISCONF='/etc/redis.conf'
         MEMCACHESERVICE='/etc/systemd/system/memcached.service'
         MEMCACHECONF='/etc/sysconfig/memcached'


### PR DESCRIPTION
```bash
/lib/systemd/system/redis.service
```

This path does not exist, using this path will give an error:

```bash
Unit redis.service could not be found.
Please check Process redis
Process mariadb is active
Some errors seem to have killed, please check this as you may need to manually fix them