### PR TITLE
remove UFW in the banner

### DIFF
--- a/Banner/classicpress
+++ b/Banner/classicpress
@@ -63,7 +63,7 @@ cat <<EOF
 ********************************************************************************
 
 $(echoCYAN 'Welcome to One-Click OpenLiteSpeed ClassicPress Server.')
-To keep this server secure, the UFW firewall is enabled.
+To keep this server secure, the firewall is enabled.
 All ports are BLOCKED except 22 (SSH), 80 (HTTP) and 443 (HTTPS).
 
 ClassicPress One-Click Quickstart guide:

--- a/Banner/wordpress
+++ b/Banner/wordpress
@@ -63,7 +63,7 @@ cat <<EOF
 ********************************************************************************
 
 $(echoCYAN 'Welcome to One-Click OpenLiteSpeed WordPress Server.')
-To keep this server secure, the UFW firewall is enabled.
+To keep this server secure, the firewall is enabled.
 All ports are BLOCKED except 22 (SSH), 80 (HTTP) and 443 (HTTPS).
 
 WordPress One-Click Quickstart guide:


### PR DESCRIPTION
it's obviously only a semantic modification
but I believe by removing UFW it make it more accurate and pro
since on CentOS the firewall is not UFW