### PR TITLE
update to set SELinux to permissive for Centos

### DIFF
--- a/Setup/cybersetup.sh
+++ b/Setup/cybersetup.sh
@@ -48,6 +48,9 @@ upgrade() {
         echo -ne '#######################   (100%)\r'
     else
         echo -ne '#                         (5%)\r'
+        echoG 'Setting SELinux to permissive'
+        setenforce 0
+        sed -i 's|^SELINUX.*|SELINUX=permissive|g' /etc/selinux/config
         yum update -y > /dev/null 2>&1
         echo -ne '#######################   (100%)\r'
     fi  


### PR DESCRIPTION
Set Centos based installs to set SELinux to permissive.
https://linuxize.com/post/how-to-disable-selinux-on-centos-8/

Before:
```
[root@cyberpanel-centos ~]# sestatus
SELinux status:                 enabled
SELinuxfs mount:                /sys/fs/selinux
SELinux root directory:         /etc/selinux
Loaded policy name:             targeted
Current mode:                   enforcing
Mode from config file:          enforcing
Policy MLS status:              enabled
Policy deny_unknown status:     allowed
Memory protection checking:     actual (secure)
Max kernel policy version:      31
```

After:
```
[root@cyberpanel-centos ~]# setenforce 0
[root@cyberpanel-centos ~]# sestatus
SELinux status:                 enabled
SELinuxfs mount:                /sys/fs/selinux
SELinux root directory:         /etc/selinux
Loaded policy name:             targeted
Current mode:                   permissive
Mode from config file:          enforcing
Policy MLS status:              enabled
Policy deny_unknown status:     allowed
Memory protection checking:     actual (secure)
Max kernel policy version:      31
[root@cyberpanel-centos ~]#
[root@cyberpanel-centos ~]# sed -i 's|^SELINUX.*|SELINUX=permissive|g' /etc/selinux/config
[root@cyberpanel-centos ~]#
```