### PR TITLE
per-instance: Fix syntax error

### DIFF
--- a/Cloud-init/per-instance.sh
+++ b/Cloud-init/per-instance.sh
@@ -756,7 +756,7 @@ maincloud(){
     elif [ "${APPLICATION}" = 'PYTHON' ]; then
         update_secretkey
         #fix_wellknown
-    elif [ "${APPLICATION}" = 'NODE' ]; then
+    #elif [ "${APPLICATION}" = 'NODE' ]; then
         #fix_wellknown
     elif [ "${APPLICATION}" = 'NONE' ]; then
         update_sql_pwd


### PR DESCRIPTION
Fix:
```
syntax error near unexpected token `elif' /dev/fd/63: line 761: ` elif [ "${APPLICATION}" = 'NONE' ]; then', exit code: 2
```

Related: https://github.com/litespeedtech/ls-cloud-image/commit/917a273b5d445b20da63d2f1dce5f9e860d1ecce