### PR TITLE
per-instance.sh: Fix syntax error

### DIFF
--- a/Cloud-init/per-instance.sh
+++ b/Cloud-init/per-instance.sh
@@ -538,7 +538,7 @@ EOM
 update_conntrack_max(){
     if [ "${PROVIDER}" = 'do' ] || [ "${PROVIDER}" = 'vultr' ] || [ "${PROVIDER}" = 'linode' ]; then
         grep nf_conntrack_max /etc/sysctl.conf >/dev/null 2>&1
-        if [ ${?} = 1 ];
+        if [ ${?} = 1 ]; then
             sysctl -w net.netfilter.nf_conntrack_max=2097152 >/dev/null
             echo "net.netfilter.nf_conntrack_max=2097152" >> /etc/sysctl.conf
         fi


### PR DESCRIPTION
Please add shell syntax PR builder, second time I create PR to upstream with shell syntax error fix @Code-Egg 
```
Line 539:
    if [ "${PROVIDER}" = 'do' ] || [ "${PROVIDER}" = 'vultr' ] || [ "${PROVIDER}" = 'linode' ]; then
>>                                                                                              ^-- SC1009: The mentioned syntax error was in this then clause.
Line 541:
        if [ ${?} = 1 ];
        ^-- SC1049: Did you forget the 'then' for this 'if'?
        ^-- SC1073: Couldn't parse this if expression. Fix to allow more checks.
Line 544:
        fi
        ^-- SC1050: Expected 'then'.
          ^-- SC1072: Unexpected keyword/token. Fix any mentioned problems and try again.
```