### PR TITLE
Fix typo

### DIFF
--- a/Setup/vhsetup.sh
+++ b/Setup/vhsetup.sh
@@ -933,7 +933,7 @@ rm_dm_lsws_svr_conf(){
 }
 
 rm_le_cert(){
-    echoG 'Remote Lets Encrypt Certificate'
+    echoG 'Remove Lets Encrypt Certificate'
     certbot delete --cert-name ${MY_DOMAIN} >/dev/null 2>&1
     certbot delete --cert-name ${MY_DOMAIN2} >/dev/null 2>&1
 }


### PR DESCRIPTION
When deleting a domain, it says `Remote Lets Encrypt Certificate` instead of `Remove Lets Encrypt Certificate`. This will fix the typo.